### PR TITLE
Allow get method to accept dot notation as argument

### DIFF
--- a/configurator/configurator.py
+++ b/configurator/configurator.py
@@ -78,7 +78,14 @@ class Configurator(object):
         return env
 
     @classmethod
-    def get(cls, section, option, default=None, raw=True, blank_default=False):
+    def get(cls, section, *args, **kwargs):
+        if '.' in section:
+            section, option = section.split('.', 1)
+            return cls._get(section, option, *args, **kwargs)
+        return cls._get(section, *args, **kwargs)
+
+    @classmethod
+    def _get(cls, section, option, default=None, raw=True, blank_default=False):
         try:
             ret = cls.config.get(section, option, raw=raw)
             if blank_default and not ret:
@@ -90,8 +97,8 @@ class Configurator(object):
             return cls.__get_env(section, option, default=default)
 
     @classmethod
-    def getboolean(cls, section, option, default=None):
-        ret = cls.get(section, option, default=default)
+    def getboolean(cls, *args, **kwargs):
+        ret = cls.get(*args, **kwargs)
         if str(ret).lower() not in cls.config._boolean_states:
             raise ValueError, 'Not a boolean: %s' % str(ret)
         return cls.config._boolean_states[str(ret).lower()]

--- a/test/configurator_tests.py
+++ b/test/configurator_tests.py
@@ -71,3 +71,13 @@ class TestSetup(unittest.TestCase):
         assert_equals(False, C.getboolean("bool","false4"))
         assert_equals(False, C.getboolean("bool","false5"))
         assert_equals(False, C.getboolean("bool","false6"))
+
+    def test_valid_formats(self):
+        C.initialize([
+            "--config", "value.one=One",
+            "--config", "value.two=Two"
+        ])
+        assert_equals("One", C.get('value', 'one', 'Three'), C.get('value.one', 'Two'))
+        assert_equals('Two', C.get('value.two'), C.get('value', 'two'))
+        assert_equals('Three', C.get('value.three', 'Three'), C.get('value', 'three', 'Three'))
+        assert_equals(None, C.get('value.four'), C.get('value', 'four'))


### PR DESCRIPTION
for example:

C.get('foo.bar') == C.get('foo', 'bar')
