### PR TITLE
Fixed configparser import for python 2 / 3 when configparser is already installed

### DIFF
--- a/configurator/configurator.py
+++ b/configurator/configurator.py
@@ -9,9 +9,9 @@ import functools
 import os
 import sys
 from future.utils import with_metaclass
-try:
+if sys.version_info >= (3, 0):
     import configparser
-except ImportError:
+else:
     import ConfigParser as configparser
 
 def addOption(option, config):

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 setup(
     name = 'pyconfigurator',
     packages = ['configurator'], # this must be the same as the name above
-    version = '0.4.13',
-    install_requires = ['future==0.15.2', 'nose', 'tox'],
+    version = '0.4.14',
+    install_requires = ['future', 'nose', 'tox'],
     description = 'A library for easy configuration',
     author = 'Charles Smith, Jeff Magnusson',
     author_email = 'charles.s.smith@gmail.com, magnussj@gmail.com',


### PR DESCRIPTION
`try` and `except` doesn't work in this case since there could be a package called configparser already installed in the environment. If that is the case, `configparser.SafeConfigParser._boolean_states` raises the following exception: `AttributeError: 'SafeConfigParser' object has no attribute '_boolean_states`.